### PR TITLE
Fix No matching distribution found for `audioop-lts` (python < 3.13)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 addict
 appdirs
-audioop-lts
+audioop-lts; python_version>='3.13'
 colour
 diskcache
 ipython>=8.18.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ include_package_data = True
 install_requires =
     addict
     appdirs
-    audioop-lts
+    audioop-lts; python_version>='3.13'
     colour
     diskcache
     ipython>=8.18.0


### PR DESCRIPTION
<!-- Thanks for contributing to manim!
    Please ensure that your pull request works with the latest version of manim.
-->

## Motivation
Fix No matching distribution found for `audioop-lts` (python < 3.13)